### PR TITLE
fix(typo)!: `seperate` -> `separate`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -68,7 +68,7 @@
 
 ```gdscript
 indentation = 0 | 1 | ... # use 0 for tabs
-seperate-label = false | true # insert space before a label
+separate-label = false | true # insert space before a label
 final-newline = false | true # insert a final newline at the end
 
 [preserve-newline]
@@ -76,7 +76,7 @@ content = false | true # preserve single newlines in markup
 math = false | true # preserve single newline in equations
 
 [block]
-long-block-style = "seperate" | "compact" # '[' and ']' on the same or seperate lines as the content
+long-block-style = "separate" | "compact" # '[' and ']' on the same or separate lines as the content
 
 [term]
 space-before = false | true # insert a space before the ':' in terms

--- a/src/logic/markup.rs
+++ b/src/logic/markup.rs
@@ -75,7 +75,7 @@ pub fn format_content_block(
                         LongBlockStyle::Compact => {
                             output.set_whitespace(Whitespace::Space, Priority::Low)
                         }
-                        LongBlockStyle::Seperate => {
+                        LongBlockStyle::Separate => {
                             output.set_whitespace(Whitespace::LineBreak, Priority::Normal)
                         }
                     }
@@ -95,7 +95,7 @@ pub fn format_content_block(
                         LongBlockStyle::Compact => {
                             output.set_whitespace(Whitespace::Space, Priority::Low)
                         }
-                        LongBlockStyle::Seperate => {
+                        LongBlockStyle::Separate => {
                             output.set_whitespace(Whitespace::LineBreak, Priority::Normal)
                         }
                     }
@@ -133,7 +133,7 @@ pub fn format_label(
     match state.mode {
         Mode::Markup => {
             let (whitespace, priority) = output.get_whitespace();
-            if settings.seperate_label {
+            if settings.separate_label {
                 output.set_whitespace(Whitespace::Space, Priority::Guaranteed);
             } else {
                 output.set_whitespace(Whitespace::None, Priority::Guaranteed);

--- a/src/logic/math.rs
+++ b/src/logic/math.rs
@@ -37,12 +37,12 @@ pub fn format_multi_line_equation(
                     output.set_whitespace(Whitespace::Space, Priority::Normal);
                     state.mode = Mode::Math;
                 }
-                (Mode::Math, LongBlockStyle::Seperate) => {
+                (Mode::Math, LongBlockStyle::Separate) => {
                     state.dedent();
                     output.set_whitespace(Whitespace::LineBreak, Priority::Normal);
                     output.raw(child, &state, settings);
                 }
-                (_, LongBlockStyle::Seperate) => {
+                (_, LongBlockStyle::Separate) => {
                     output.raw(child, &state, settings);
                     state.indent();
                     output.set_whitespace(Whitespace::LineBreak, Priority::Normal);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -70,7 +70,7 @@ pub enum UseLongBlock {
 #[serde(rename_all = "kebab-case")]
 pub enum LongBlockStyle {
     Compact,
-    Seperate,
+    Separate,
 }
 
 #[derive(Deserialize, Serialize, Debug)]
@@ -131,7 +131,7 @@ create_normal_and_partial!(
 
     struct Settings | PartialSettings {
         pub indentation: usize,
-        pub seperate_label: bool,
+        pub separate_label: bool,
         pub final_newline: bool,
         pub preserve_newline: PreserveNewLine,
         pub block: BlockSettings,

--- a/src/styles.rs
+++ b/src/styles.rs
@@ -17,7 +17,7 @@ impl Styles {
         match self {
             Self::Default => Settings {
                 indentation: 2,
-                seperate_label: true,
+                separate_label: true,
                 preserve_newline: PreserveNewLine {
                     content: true,
                     math: true,
@@ -65,7 +65,7 @@ impl Styles {
             },
             Self::Otbs => Settings {
                 indentation: 0,
-                seperate_label: true,
+                separate_label: true,
                 preserve_newline: PreserveNewLine {
                     content: false,
                     math: true,
@@ -94,7 +94,7 @@ impl Styles {
                     comma: AlignComma::EndOfContent,
                 },
                 block: BlockSettings {
-                    long_block_style: LongBlockStyle::Seperate,
+                    long_block_style: LongBlockStyle::Separate,
                 },
                 final_newline: true,
                 heading: HeadingSettings {


### PR DESCRIPTION
Thanks for creating a configurable formatter for Typst!

I think it will avoid confusion in the config files if we correct the spelling of `separate` across the repo.